### PR TITLE
Fix circular dependency

### DIFF
--- a/modules/b/b-api/build.gradle
+++ b/modules/b/b-api/build.gradle
@@ -1,3 +1,2 @@
 dependencies {
-    implementation project(':modules:b:b-api')
 }


### PR DESCRIPTION
``` 
Circular` dependency between the following tasks:
:modules:b:b-api:classes
\--- :modules:b:b-api:compileJava
     \--- :modules:b:b-api:jar
          \--- :modules:b:b-api:classes (*)
```